### PR TITLE
Popups positioning and right numpad support

### DIFF
--- a/tek/ui/class/textedit.lua
+++ b/tek/ui/class/textedit.lua
@@ -1945,7 +1945,9 @@ function TextEdit:handleKeyboard(msg)
 				-- db.warn("ctrl+delete")
 				break
 			end
-			if qual > 3 or code == 27 then -- ctrl, alt, esc, ...
+			
+			-- allowing the qual 256 makes the right numpad work
+			if (qual > 3 and qual ~= 256) or code == 27 then -- ctrl, alt, esc, ...
 				if ml and (code == 0xf023 or code == 0xf024) then
 					-- relinquish qual+pageup/down
 				else

--- a/tek/ui/class/window.lua
+++ b/tek/ui/class/window.lua
@@ -617,6 +617,11 @@ function Window:show()
 		self.Application:openWindow(self)
 		Group.show(self, d)
 		self:layout()
+
+		-- Makes the window have the correct placement of popups at the start
+		local _, _, dx, dy = self.Drawable:getAttrs()
+		self.Drawable:setAttrs { Left = dx+1, Top = dy }
+		self.Drawable:setAttrs { Left = dx, Top = dy }
 	end
 end
 


### PR DESCRIPTION
Made an extra set of the drawable position in the window:show method to have it's position correct for any popup that is created after.
Added the qualifier of the right numpad in keyboard to the textedit checks so it is supported.