### PR TITLE
Fixed theme loading on windows

### DIFF
--- a/tek/ui.lua
+++ b/tek/ui.lua
@@ -690,7 +690,13 @@ function ui.loadStyleSheet(file)
 	local fh, msg
 	db.info("loadstylesheet: '%s'", file)
 	if type(file) == "string" then
-		fh, msg = openUIPath(("tek/ui/style/%s.css"):format(file))
+		-- Check if its running in Windows
+		if package.config:sub(1,1) == "\\" then
+			fh, msg = openUIPath(("tek\\ui\\style\\%s.css"):format(file))
+		else
+			fh, msg = openUIPath(("tek/ui/style/%s.css"):format(file))
+		end
+
 		if not fh then
 			return nil, msg
 		end

--- a/tek/ui/class/border.lua
+++ b/tek/ui/class/border.lua
@@ -23,6 +23,10 @@ function Border:layout(x0, y0, x1, y1)
 	if not x0 then
 		x0, y0, x1, y1 = self.Parent:getRect()
 	end
+	if not x0 then
+		-- Prevent crash
+		x0, y0, x1, y1 = 0, 0, 0, 0
+	end
 	self.Rect:setRect(x0, y0, x1, y1)
 	return x0, y0, x1, y1
 end


### PR DESCRIPTION
Themes loading on windows was failing. Added check to use a specific path for windows.
Also prevented crash on layout call.